### PR TITLE
Extend ServiceMonitor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The following table lists the configurable parameters of the process exporter ch
 | `serviceAccount.name`               | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                         |
 | `serviceAccount.imagePullSecrets`   | Specify image pull secrets                                                                                                    | `[]`                                    |
 | `serviceMonitor.enabled`            | if `true`, creates a Prometheus Operator ServiceMonitor                                                                       | `false`                                 |
+| `serviceMonitor.labels`             | Set of labels to apply on ServiceMonitor                                                                                      | `{}`                                    |
+| `serviceMonitor.interval`           | Set custom metric scraping interval ServiceMonitor, must be string                                                            | `10s`                                   |
 | `securityContext`                   | SecurityContext                                                                                                               | `{"runAsNonRoot": true, "runAsUser": 65534}` |
 | `affinity`                          | A group of affinity scheduling rules for pod assignment                                                                       | `{}`                                    |
 | `nodeSelector`                      | Node labels for pod assignment                                                                                                | `{}`                                    |

--- a/charts/prometheus-process-exporter/Chart.yaml
+++ b/charts/prometheus-process-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: A Helm chart for prometheus process-exporter
 name: prometheus-process-exporter
-version: 0.4.0
+version: 0.4.1
 home: https://github.com/mumoshu/prometheus-process-exporter
 sources:
 - https://github.com/ncabatoff/process-exporter

--- a/charts/prometheus-process-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-process-exporter/templates/servicemonitor.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - interval: 10s
+  - interval: "{{ .Values.serviceMonitor.interval }}"
     honorLabels: true
     port: metrics
     path: /metrics

--- a/charts/prometheus-process-exporter/values.yaml
+++ b/charts/prometheus-process-exporter/values.yaml
@@ -23,6 +23,8 @@ groups:
 ## Creates a Prometheus Operator ServiceMonitor
 serviceMonitor:
   enabled: false
+  interval: "10s"
+  labels: {}
 
 service:
   type: ClusterIP


### PR DESCRIPTION
- Add scraping interval to ServiceMonontior template.
I needed more frequent scrapes than 10s.
- Fix missing labels section for ServiceMonitor in `values.yaml` and `README.md`