### PR TITLE
Ability to customize daemonset update strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following table lists the configurable parameters of the process exporter ch
 | `readinessProbe.periodSeconds`      | Amount of seconds between the probes                                                                                          | `10`                                    |
 | `readinessProbe.failureThreshold`   | Amount of probe failures before the pod is restared                                                                           | `3`                                     |
 | `readinessProbe.successThreshold`   | Amount of consecutive probe successes to mark the pod as ready                                                                | `1`                                     |
-
+| `updateStrategy`  | Update strategy for the daemonset   |   `Rolling update with 1 max unavailable` |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console

--- a/charts/prometheus-process-exporter/Chart.yaml
+++ b/charts/prometheus-process-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: A Helm chart for prometheus process-exporter
 name: prometheus-process-exporter
-version: 0.4.1
+version: 0.4.2
 home: https://github.com/mumoshu/prometheus-process-exporter
 sources:
 - https://github.com/ncabatoff/process-exporter

--- a/charts/prometheus-process-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-process-exporter/templates/daemonset.yaml
@@ -8,10 +8,10 @@ spec:
     matchLabels:
       app: {{ template "prometheus-process-exporter.name" . }}
       release: {{ .Release.Name }}
+{{- if .Values.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+{{ toYaml .Values.updateStrategy | indent 4 }}
+{{- end }}
   template:
     metadata:
       labels: {{ include "prometheus-process-exporter.labels" . | indent 8 }}

--- a/charts/prometheus-process-exporter/values.yaml
+++ b/charts/prometheus-process-exporter/values.yaml
@@ -37,6 +37,14 @@ service:
 # Annotations to add to the pod	
 podAnnotations: {}
 
+# Set to Kubernetes default updateStrategy by default.
+# See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy for
+# supported configurations.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/prometheus-process-exporter/values.yaml
+++ b/charts/prometheus-process-exporter/values.yaml
@@ -6,7 +6,7 @@ image:
   tag: 0.5.0
   pullPolicy: IfNotPresent
 
-## Specify entries of `process_names:` in the process-expoter config
+## Specify entries of `process_names:` in the process-exporter config
 ## See https://github.com/ncabatoff/process-exporter/tree/master#using-a-config-file
 groups:
 - comm:


### PR DESCRIPTION
The `updateStrategy` was previously fixed to be the kubernetes default update strategy for daemonsets of a `maxUnavailable` of 1 replica. We found the default strategy could pose some challenges for larger clusters, as it can take a long time to gradually roll out replicas one by one. Additionally, with the default strategy a single unhealthy node where replicas could not be scheduled could sometimes interrupt the rollout of the process-exporter to remaining healthy nodes.

This change gives the ability to customize the `updateStrategy` if desired, and leaves the default kubernetes update strategy in the `values.yaml` file. 

