### PR TITLE
add optional relabeling configs to serviceMonitor object

### DIFF
--- a/charts/prometheus-process-exporter/Chart.yaml
+++ b/charts/prometheus-process-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus process-exporter
 name: prometheus-process-exporter
-version: 0.5.0
+version: 0.6.0
 home: https://github.com/mumoshu/prometheus-process-exporter
 sources:
 - https://github.com/ncabatoff/process-exporter

--- a/charts/prometheus-process-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-process-exporter/templates/servicemonitor.yaml
@@ -19,6 +19,12 @@ spec:
     port: metrics
     path: /metrics
     scheme: http
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:

--- a/charts/prometheus-process-exporter/values.yaml
+++ b/charts/prometheus-process-exporter/values.yaml
@@ -25,6 +25,10 @@ serviceMonitor:
   enabled: false
   interval: "10s"
   labels: {}
+  # Additional general relabeling
+  relabelings: []
+  # Additional metric relabeling
+  metricRelabelings: []
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Adds the ability to configure `metricRelabelings` and `relabelings` for the `serviceMonitor` object.

Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint

This should also close https://github.com/mumoshu/prometheus-process-exporter/issues/23
